### PR TITLE
Caching of bootstrap

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,5 +1,3 @@
-{% extends "bootstrap/base.html" %}
-
 {% block title %}Flasky{% endblock %}
 
 {% block head %}
@@ -7,6 +5,7 @@
 <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
 <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles.css') }}">
+<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 {% endblock %}
 
 {% block navbar %}


### PR DESCRIPTION
The bootstrap here called doesn't get properly cached making site slow to load. A CDN link can be used to solve the problem.
